### PR TITLE
Importar type VariantProps no componente Button Icon

### DIFF
--- a/src/components/button-icon.tsx
+++ b/src/components/button-icon.tsx
@@ -1,4 +1,4 @@
-import { cva, VariantProps } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import Icon from "./icon";
 
 export const buttonIconVariants = cva(


### PR DESCRIPTION
Correção para importar `type VariantProps` de `class-variance-authority`.